### PR TITLE
add sectionsep param to docs

### DIFF
--- a/layeredconfig/environment.py
+++ b/layeredconfig/environment.py
@@ -24,7 +24,8 @@ class Environment(ConfigSource):
         :param lower: If true, lowercase the name of environment
                       variables (since these typically uses uppercase)
         :type  lower: True
-
+        :param sectionsep: An alternate section separator instead of ``-``.
+        :type  sectionsep: str
         """
         super(Environment, self).__init__(**kwargs)
         if environ is None:


### PR DESCRIPTION
I noticed that the `sectionsep` param was not called out in the body of the documentation while researching how to override this param.  So, I've added it.